### PR TITLE
Add normalization

### DIFF
--- a/src/weave/smoother.py
+++ b/src/weave/smoother.py
@@ -567,13 +567,18 @@ class Smoother:
         ------
         ValueError
             If `data` contains NaNs or Infs.
+            If `stdev` contains zeros or negative values.
 
         """
+        # TODO: write test for stdev check
         if data.isna().any(axis=None):
             raise ValueError("`data` contains NaNs")
         cols_in = [observed] if stdev is None else [observed, stdev]
         if np.isinf(data[names + coords + cols_in]).any(axis=None):
             raise ValueError("`data` contains Infs")
+        if stdev is not None:
+            if np.any(data[stdev] >= 0):
+                raise ValueError("`stdev` values must be positive")
 
     def check_dim_values(
         self,


### PR DESCRIPTION
* switch the order of the for loop, loop over rows are on the outside
* add normalization for the weights from outside of the current time series
* revert back to without `col_weights` (my bad wrong idea in the beginning)
* turn off the parallel feature due to issue https://github.com/numba/numba/issues/5601